### PR TITLE
kernel: Use the stock config for /proc/config.gz

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -133,7 +133,7 @@ obj-$(CONFIG_INTELLIGENCE) += intelligence.o
 $(obj)/configs.o: $(obj)/config_data.h
 
 targets += config_data.gz
-$(obj)/config_data.gz: out/.config FORCE
+$(obj)/config_data.gz: arch/arm64/configs/vendor/r8q_eur_open_defconfig FORCE
 	$(call if_changed,gzip)
 
       filechk_ikconfiggz = (echo "static const char kernel_config_data[] __used = MAGIC_START"; cat $< | scripts/bin2c; echo "MAGIC_END;")


### PR DESCRIPTION
We need to do this, for fix "internal problem" after boot